### PR TITLE
Moved Development Depedencies to Dependencies where they belong.

### DIFF
--- a/packages/vue3-marquee/package.json
+++ b/packages/vue3-marquee/package.json
@@ -25,6 +25,9 @@
     "type-check": "vue-tsc --build --force"
   },
   "dependencies": {
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "vue": "^3.3.11"
   },
@@ -33,10 +36,7 @@
     "@types/node": "^18.19.3",
     "@vitejs/plugin-vue": "^4.5.2",
     "@vue/tsconfig": "^0.5.0",
-    "autoprefixer": "^10.4.17",
     "npm-run-all2": "^6.1.1",
-    "postcss": "^8.4.33",
-    "tailwindcss": "^3.4.1",
     "typescript": "~5.3.0",
     "vite": "^5.0.10",
     "vite-plugin-dts": "^3.7.2",


### PR DESCRIPTION
After installing Marquee, the installation complained that Tailwind CSS was missing and using certain classes, aren't working because of that.

Moving Tailwind CSS from Developer Dependencies to Dependencies, solves this issue.